### PR TITLE
Clarify effects modifiers types

### DIFF
--- a/src/AccountManager.ts
+++ b/src/AccountManager.ts
@@ -48,7 +48,7 @@ export class AccountManager {
 	 * @param {string} username
 	 * @param {boolean} force Force reload data from disk
 	 */
-	async loadAccount(username: string, force: boolean) {
+	async loadAccount(username: string, force?: boolean) {
 		if (this.accounts.has(username) && !force) {
 			return this.getAccount(username);
 		}

--- a/src/BundleManager.ts
+++ b/src/BundleManager.ts
@@ -398,9 +398,7 @@ export class BundleManager {
 		}
 		return entities.map((entity: GameEntityDefinition) => {
 			const entityRef = factory.createEntityRef(areaName, entity.id);
-			console.log('entity before ', entity);
 			entity.area = areaName;
-			console.log('entity after ', entity);
 			factory.setDefinition(entityRef, entity);
 			if (entity.script !== undefined) {
 				let scriptPath = '';

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -7,9 +7,13 @@ import { EventListeners } from './EventManager';
 import { PlayerOrNpc } from './GameEntity';
 import { Character } from './Character';
 
+export type AttributesModifier =
+	| Record<string, (this: Effect, current: number, ...args: any[]) => any>
+	| ((this: Effect, attrName: string, current: number) => any)
+
 /** @typedef EffectModifiers {{attributes: !Object<string,function>}} */
 export type EffectModifiers = {
-	attributes: Record<string, (...args: any[]) => any>;
+	attributes: AttributesModifier;
 	incomingDamage: (
 		damage: Damage,
 		currentAmount: number,
@@ -20,7 +24,7 @@ export type EffectModifiers = {
 		currentAmount: number,
 		target: PlayerOrNpc
 	) => any;
-	properties: (...args: any[]) => any | Record<string, (...args: any[]) => any>;
+	properties: AttributesModifier;
 };
 
 export interface IEffectDef {
@@ -30,7 +34,7 @@ export interface IEffectDef {
 	flags?: string[];
 	skill?: string;
 	/** @property {EffectModifiers} modifiers Attribute modifier functions */
-	modifiers?: EffectModifiers;
+	modifiers?: Partial<EffectModifiers>;
 	state?: Partial<IEffectState>;
 	listeners?: EventListeners;
 }
@@ -156,9 +160,10 @@ export class Effect extends EventEmitter {
 		this.modifiers = Object.assign(
 			{
 				attributes: {},
-				incomingDamage: (damage: Damage, current: number) => current,
-				outgoingDamage: (damage: Damage, current: number) => current,
-			},
+				incomingDamage: (_damage: Damage, current: number) => current,
+				outgoingDamage: (_damage: Damage, current: number) => current,
+				properties: {},
+			} as EffectModifiers,
 			def.modifiers
 		);
 
@@ -317,12 +322,13 @@ export class Effect extends EventEmitter {
 	 */
 	modifyAttribute(attrName: string, currentValue: number) {
 		let modifier = (_?: any) => _;
-		if (typeof this.modifiers.attributes === 'function') {
+		const attributeModifiers = this.modifiers.attributes;
+		if (typeof attributeModifiers === 'function') {
 			modifier = (current) => {
-				return this.modifiers.attributes.bind(this)(attrName, current);
+				return attributeModifiers.bind(this)(attrName, current);
 			};
-		} else if (attrName in this.modifiers.attributes) {
-			modifier = this.modifiers.attributes[attrName];
+		} else if (attrName in attributeModifiers) {
+			modifier = attributeModifiers[attrName];
 		}
 		return modifier.bind(this)(currentValue);
 	}
@@ -336,12 +342,13 @@ export class Effect extends EventEmitter {
 	 */
 	modifyProperty(propertyName: string, currentValue: number) {
 		let modifier = (_: any) => _;
-		if (typeof this.modifiers.properties === 'function') {
+		const propertyModifiers = this.modifiers.properties;
+		if (typeof propertyModifiers === 'function') {
 			modifier = (current) => {
-				return this.modifiers.properties.bind(this)(propertyName, current);
+				return propertyModifiers.bind(this)(propertyName, current);
 			};
-		} else if (propertyName in this.modifiers.properties) {
-			modifier = this.modifiers.properties[propertyName];
+		} else if (propertyName in propertyModifiers) {
+			modifier = propertyModifiers[propertyName];
 		}
 		return modifier.bind(this)(currentValue);
 	}

--- a/src/Effect.ts
+++ b/src/Effect.ts
@@ -36,7 +36,7 @@ export interface IEffectDef {
 	/** @property {EffectModifiers} modifiers Attribute modifier functions */
 	modifiers?: Partial<EffectModifiers>;
 	state?: Partial<IEffectState>;
-	listeners?: EventListeners;
+	listeners?: EventListeners<Effect>;
 }
 
 export interface ISerializedEffect {

--- a/src/EffectableEntity.ts
+++ b/src/EffectableEntity.ts
@@ -63,7 +63,7 @@ export class EffectableEntity extends EventEmitter {
 	 * @param {string} attr
 	 * @return {number}
 	 */
-	getMaxAttribute(attrString: string) {
+	getMaxAttribute(attrString: string): number {
 		if (!this.hasAttribute(attrString)) {
 			throw new RangeError(`Entity does not have attribute [${attrString}]`);
 		}
@@ -104,7 +104,7 @@ export class EffectableEntity extends EventEmitter {
 	 * @param {string} attrString
 	 * @return {number}
 	 */
-	getAttribute(attrName: string) {
+	getAttribute(attrName: string): number {
 		const attr = this.attributes.get(attrName);
 		if (!attr || !this.hasAttribute(attrName)) {
 			throw new RangeError(`Entity does not have attribute [${attrName}]`);
@@ -145,9 +145,9 @@ export class EffectableEntity extends EventEmitter {
 	 * @param {string} attrName Attribute name
 	 * @return {number}
 	 */
-	getBaseAttribute(attrName: string) {
+	getBaseAttribute(attrName: string): number {
 		const attr = this.attributes.get(attrName);
-		return attr && attr.base;
+		return attr && attr.base || 0;
 	}
 
 	/**
@@ -257,7 +257,7 @@ export class EffectableEntity extends EventEmitter {
 	/**
 	 * @see EffectList.evaluateIncomingDamage
 	 * @param {Damage} damage
-   * @param {number} currentAmount
+	 * @param {number} currentAmount
 	 * @param {?Character} attacker
 	 * @return {number}
 	 */

--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -2,9 +2,11 @@ import { EventEmitter } from 'events';
 import { IGameState } from './GameState';
 import { isIterable } from './Util';
 
-export type EventListeners =
-	| Record<string, () => void>
-	| ((state: IGameState) => Record<string, () => void>);
+type EventListenersRecord<T> = Record<string, (this: T, ...args: unknown[]) => void>;
+
+export type EventListeners<T = unknown> =
+	| EventListenersRecord<T>
+	| ((state: IGameState) => EventListenersRecord<T>);
 
 /**
  * Generic array hash table to store listener definitions `events` is a `Map`

--- a/src/Inventory.ts
+++ b/src/Inventory.ts
@@ -9,7 +9,7 @@ export interface IInventoryDef {
 }
 
 export interface ISerializedInventory {
-	items?: [string, IItemDef][];
+	items?: [string, ISerializedItem][];
 	max?: number;
 }
 

--- a/src/Item.ts
+++ b/src/Item.ts
@@ -103,7 +103,7 @@ export class Item extends GameEntity {
 	room: string | Room | null;
 	roomDesc: string;
 	script: string | null;
-	type: ItemType | string;
+	type: ItemType;
 	uuid: string;
 	closeable: boolean;
 	closed: boolean;
@@ -152,7 +152,7 @@ export class Item extends GameEntity {
 		this.script = item.script || null;
 
 		if (typeof item.type === 'string') {
-			this.type = item.type;
+			this.type = item.type as ItemType;
 		} else {
 			this.type = item.type || ItemType.OBJECT;
 		}

--- a/src/ItemType.ts
+++ b/src/ItemType.ts
@@ -1,11 +1,11 @@
 export const ItemType = {
-	OBJECT: 1,
-	CONTAINER: 2,
-	ARMOR: 3,
-	WEAPON: 4,
-	POTION: 5,
-	RESOURCE: 6,
-	COMMUNICATOR: 7,
+	OBJECT: 'OBJECT',
+	CONTAINER: 'CONTAINER',
+	ARMOR: 'ARMOR',
+	WEAPON: 'WEAPON',
+	POTION: 'POTION',
+	RESOURCE: 'RESOURCE',
+	COMMUNICATOR: 'COMMUNICATOR',
 } as const;
 
 export type ItemType = typeof ItemType[keyof typeof ItemType];

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -9,7 +9,7 @@ import { CommandQueue, ICommandExecutable } from './CommandQueue';
 import { Config } from './Config';
 import { IGameState } from './GameState';
 import { IInventoryDef } from './Inventory';
-import { IItemDef } from './Item';
+import { IItemDef, ISerializedItem } from './Item';
 import { Logger } from './Logger';
 import { Metadata } from './Metadatable';
 import { PlayerRoles } from './PlayerRoles';
@@ -316,8 +316,8 @@ export class Player extends Character {
 		});
 
 		if (this.equipment instanceof Map) {
-			let eq: Record<string, IItemDef> = {};
-			for (let [slot, item] of this.equipment) {
+			const eq: Record<string, ISerializedItem> = {};
+			for (const [slot, item] of this.equipment) {
 				eq[slot] = item.serialize();
 			}
 			data.equipment = eq;

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -246,7 +246,6 @@ export class Player extends Character {
 		if (this.__equipment && !this.equipment.size) {
 			const eqDefs = this.__equipment as Record<string, IItemDef>;
 			this.equipment = new Map();
-			console.log({ eqDefs });
 			for (const slot in eqDefs) {
 				const itemDef= eqDefs[slot];
 				try {

--- a/src/PlayerManager.ts
+++ b/src/PlayerManager.ts
@@ -120,7 +120,7 @@ export class PlayerManager extends EventEmitter {
 		state: IGameState,
 		account: Account,
 		username: string,
-		force: boolean
+		force?: boolean
 	) {
 		if (this.players.has(username) && !force) {
 			return this.getPlayer(username);

--- a/src/TransportStream.ts
+++ b/src/TransportStream.ts
@@ -1,6 +1,9 @@
 import { EventEmitter } from 'events';
 import { TelnetStream } from '../types/TelnetStream';
 import { WebsocketStream } from '../types/WebsocketStream';
+
+export type SocketType = TelnetStream | WebsocketStream;
+
 /**
  * Base class for anything that should be sending or receiving data from the player
  */


### PR DESCRIPTION
This removes some logs and sets the `force` property to option in one spot.

Aside from those small tweaks, the meat of this PR improves the types for the Effect class, particularly the Attributes and properties modifiers, which previously used a lot of `any` but now gets specific about what it expects as well as the `this` context available to said functions.