### PR TITLE
Remove type check, typescript ensures there are numbers

### DIFF
--- a/src/Attribute.ts
+++ b/src/Attribute.ts
@@ -54,12 +54,6 @@ export class Attribute {
 		formula: AttributeFormula | null,
 		metadata: Metadata
 	) {
-		if (isNaN(base)) {
-			throw new TypeError(`Base attribute must be a number, got ${base}.`);
-		}
-		if (isNaN(delta)) {
-			throw new TypeError(`Attribute delta must be a number, got ${delta}.`);
-		}
 		if (formula && !(formula instanceof AttributeFormula)) {
 			throw new TypeError(
 				'Attribute formula must be instance of AttributeFormula'


### PR DESCRIPTION
Parameters _delta_ and _base_ type are ensured by typescript. No need to have a  check to confirm they're numbers.