### PR TITLE
Add respawn props to Npc/Item Room defs

### DIFF
--- a/src/Room.ts
+++ b/src/Room.ts
@@ -43,12 +43,15 @@ export interface IRoomDef {
 
 export interface IRoomItemDef {
 	id: string;
+	replaceOnRespawn?: boolean;
 	respawnChance?: number;
 	maxLoad?: number;
 }
 
 export interface IRoomNpcDef {
 	id: string;
+	maxLoad?: number;
+	respawnChance?: number; // percentage
 }
 
 /**


### PR DESCRIPTION
This adds some optional props related to respawning. These props are used in the "default" progressive-respawn script and may be useful otherwise too; I left them optional so as to not disrupt people using different respawn methods or props, but felt it made sense to have the `maxLoad` and similar props since they are already included in some types.