### PR TITLE
Remove isIterable code due to types being checked typescript

### DIFF
--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -73,9 +73,7 @@ export class EventManager {
 			events = [events];
 		} else if (!events) {
 			events = this.events.keys();
-		} else if (!isIterable(events)) {
-			throw new TypeError('events list passed to detach() is not iterable');
-		}
+		} 
 
 		for (const event of events) {
 			emitter.removeAllListeners(event);

--- a/src/EventManager.ts
+++ b/src/EventManager.ts
@@ -1,6 +1,5 @@
 import { EventEmitter } from 'events';
 import { IGameState } from './GameState';
-import { isIterable } from './Util';
 
 type EventListenersRecord<T> = Record<string, (this: T, ...args: unknown[]) => void>;
 

--- a/src/Util.ts
+++ b/src/Util.ts
@@ -7,6 +7,6 @@ export type Constructor<T = EventEmitter> = new (...args: any[]) => T;
  * @param {Object} obj
  * @return {boolean}
  */
-export function isIterable(obj: Iterable<unknown>) {
+export function isIterable(obj: Iterable<unknown>):boolean {
 	return obj && typeof obj[Symbol.iterator] === 'function';
 }


### PR DESCRIPTION
**Reduce code leveraging TypeScript type checks**

`Util::isIterable(obj: Iterable<unknown>)` is used in `EventManager` to check the events received in `detach(...)`are iterable. This is needed in JS because there's no type check.

In the TypeScript version of the code the method `detach` checks that events are `string | Iterable<string>` so there's no possibility of receiving events that's are not iterable or string (and string is already considered in an if brach).