### PR TITLE
Attempt to add generic types to getMeta

### DIFF
--- a/src/Metadatable.ts
+++ b/src/Metadatable.ts
@@ -77,7 +77,7 @@ export function Metadatable<TBase extends Constructor>(ParentClass: TBase) {
 			}
 
 			const base = this.metadata;
-			return key.split('.').reduce((obj, index) => obj && obj[index], base);
+			return (key as string).split('.').reduce((obj: any, index) => obj && obj[index], base);
 		}
 	};
 }

--- a/src/Metadatable.ts
+++ b/src/Metadatable.ts
@@ -71,7 +71,7 @@ export function Metadatable<TBase extends Constructor>(ParentClass: TBase) {
 		 * @return {*}
 		 * @throws Error
 		 */
-		getMeta(key: string) {
+		getMeta<TMeta extends Metadata, TKey extends keyof TMeta>(key: TKey): TMeta[TKey] {
 			if (!this.metadata) {
 				throw new Error('Class does not have metadata property');
 			}


### PR DESCRIPTION
Tried adding typing to `getMeta` as a proof of concept for these kind of methods that we currently have typed as returning `any` but should possibly be typed by the user with our help. Right now it's failing to install properly with this error:

```
npm ERR! prepareGitDep src/Metadatable.ts(80,15): error TS2339: Property 'split' does not exist on type 'TKey'.
npm ERR! prepareGitDep src/Metadatable.ts(80,34): error TS7006: Parameter 'obj' implicitly has an 'any' type.
npm ERR! prepareGitDep src/Metadatable.ts(80,39): error TS7006: Parameter 'index' implicitly has an 'any' type.
```

At this time I'm also not sure it would be worth the effort both for us and for users typing their metadata when they could also use type assertions.

My attempt here is based on mimicking some of the typing for Lodash's `_.get` method, which can be seen here:
https://github.com/DefinitelyTyped/DefinitelyTyped/blob/master/types/lodash/common/object.d.ts#L1112

As you can see, it would be challenging to properly type `getMeta` for nested metadata.