### PR TITLE
Avoid using object type

### DIFF
--- a/src/Area.ts
+++ b/src/Area.ts
@@ -91,7 +91,7 @@ export class Area extends GameEntity {
 	 * @param {string} id Room id
 	 * @return {Room|undefined}
 	 */
-	getRoomById(id: string): Room | never {
+	getRoomById(id: string): Room {
 		const room = this.rooms.get(id);
 		if (!room) {
 			throw new Error(`Area did not find Room with id: [${id}]`);

--- a/src/EntityFactory.ts
+++ b/src/EntityFactory.ts
@@ -88,7 +88,7 @@ export class EntityFactory {
 	) {
 		const definition = this.getDefinition(entityRef);
 		if (!definition) {
-			throw new Error(`[${Type}Factory] No Entity definition found for ${entityRef}`);
+			throw new Error(`[${Type.name}Factory] No Entity definition found for ${entityRef}`);
 		}
 		const entity = new Type(area, definition);
 

--- a/src/Quest.ts
+++ b/src/Quest.ts
@@ -167,7 +167,7 @@ export class Quest extends EventEmitter {
 	}
 
 	hydrate() {
-		(this.state as ISerializedQuestDef[]).forEach((goalState, i: number) => {
+		(this.state as ISerializedQuestGoal[]).forEach((goalState, i: number) => {
 			this.goals[i].hydrate(goalState.state);
 		});
 	}

--- a/src/QuestGoal.ts
+++ b/src/QuestGoal.ts
@@ -9,7 +9,7 @@ export interface IQuestGoalDef {
 }
 
 export interface ISerializedQuestGoal {
-	state: object;
+	state: Record<string, unknown>;
 	progress: {
 		percent: number;
 		display: string;
@@ -30,7 +30,7 @@ export interface IQuestGoalConfig {
 export class QuestGoal extends EventEmitter {
 	config: IQuestGoalConfig;
 	quest: Quest;
-	state: object;
+	state: Record<string, unknown>;
 	player: Player;
 	/**
 	 * @param {Quest} quest Quest this goal is for
@@ -75,7 +75,7 @@ export class QuestGoal extends EventEmitter {
 		};
 	}
 
-	hydrate(state: object) {
+	hydrate(state: Record<string, unknown>) {
 		this.state = state;
 	}
 }

--- a/src/QuestGoal.ts
+++ b/src/QuestGoal.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { Player } from './Player';
-import { ISerializedQuestDef, Quest } from './Quest';
+import { Quest } from './Quest';
 
 export interface IQuestGoalDef {
 	name: string;
@@ -51,10 +51,7 @@ export class QuestGoal<TState = Record<string, unknown>> extends EventEmitter {
 		this.player = player;
 	}
 
-	/**
-	 * @return {{ percent: number, display: string}}
-	 */
-	getProgress() {
+	getProgress(): { percent: number, display: string} {
 		return {
 			percent: 0,
 			display:

--- a/src/QuestGoal.ts
+++ b/src/QuestGoal.ts
@@ -30,7 +30,7 @@ export interface IQuestGoalConfig {
 export class QuestGoal<TState = Record<string, unknown>> extends EventEmitter {
 	config: IQuestGoalConfig;
 	quest: Quest;
-	state: TState;
+	state: Partial<TState>;
 	player: Player;
 	/**
 	 * @param {Quest} quest Quest this goal is for
@@ -47,7 +47,7 @@ export class QuestGoal<TState = Record<string, unknown>> extends EventEmitter {
 			config
 		);
 		this.quest = quest;
-		this.state = {} as TState;
+		this.state = {};
 		this.player = player;
 	}
 

--- a/src/QuestGoal.ts
+++ b/src/QuestGoal.ts
@@ -27,7 +27,7 @@ export interface IQuestGoalConfig {
  * create new quest goals for quests
  * @extends EventEmitter
  */
-export class QuestGoal<TState = ISerializedQuestGoal[]> extends EventEmitter {
+export class QuestGoal<TState = Record<string, unknown>> extends EventEmitter {
 	config: IQuestGoalConfig;
 	quest: Quest;
 	state: TState;

--- a/src/QuestGoal.ts
+++ b/src/QuestGoal.ts
@@ -1,6 +1,6 @@
 import { EventEmitter } from 'events';
 import { Player } from './Player';
-import { Quest } from './Quest';
+import { ISerializedQuestDef, Quest } from './Quest';
 
 export interface IQuestGoalDef {
 	name: string;
@@ -27,10 +27,10 @@ export interface IQuestGoalConfig {
  * create new quest goals for quests
  * @extends EventEmitter
  */
-export class QuestGoal extends EventEmitter {
+export class QuestGoal<TState = ISerializedQuestGoal[]> extends EventEmitter {
 	config: IQuestGoalConfig;
 	quest: Quest;
-	state: Record<string, unknown>;
+	state: TState;
 	player: Player;
 	/**
 	 * @param {Quest} quest Quest this goal is for
@@ -47,7 +47,7 @@ export class QuestGoal extends EventEmitter {
 			config
 		);
 		this.quest = quest;
-		this.state = {};
+		this.state = {} as TState;
 		this.player = player;
 	}
 
@@ -69,13 +69,13 @@ export class QuestGoal extends EventEmitter {
 
 	serialize(): ISerializedQuestGoal {
 		return {
-			state: this.state,
+			state: this.state as Record<string, unknown>,
 			progress: this.getProgress(),
 			config: this.config,
 		};
 	}
 
-	hydrate(state: Record<string, unknown>) {
+	hydrate(state: TState) {
 		this.state = state;
 	}
 }


### PR DESCRIPTION
Object type leads to issues whenever you attempt to use a property on it, `Record<string, unknown>` is easier for the user to extend. We could also use `Record<string, any>` which is much more permissive/flexible.