### PR TITLE
Fix tickInterval

### DIFF
--- a/src/EffectList.ts
+++ b/src/EffectList.ts
@@ -99,7 +99,7 @@ export class EffectList {
 					continue;
 				}
 				effect.state.lastTick = now;
-				if (!effect.state.ticks) {
+				if (!effect.state.ticks && effect.state.ticks !== 0) {
 					effect.state.ticks = 0;
 				}
 				effect.state.ticks++;

--- a/src/EffectList.ts
+++ b/src/EffectList.ts
@@ -91,14 +91,18 @@ export class EffectList {
 				typeof effect.config.tickInterval !== 'undefined'
 			) {
 				const now = Date.now();
+				const sinceLastTick = now - effect.state.lastTick;
 				if (
-					Date.now() <
-					effect.state.ticks * effect.config.tickInterval * 1000
+					sinceLastTick <
+					effect.config.tickInterval * 1000
 				) {
 					continue;
 				}
 				effect.state.lastTick = now;
-				effect.state.ticks && effect.state.ticks++;
+				if (!effect.state.ticks) {
+					effect.state.ticks = 0;
+				}
+				effect.state.ticks++;
 			}
 			(effect as Effect).emit(event, ...args);
 		}


### PR DESCRIPTION
This was broken at some point (perhaps since the advent of 3.1?) by faulty logic. This addresses that and fixes it.

Co-authored by: @nelsonsbrian 