### PR TITLE
Add  Socket types.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -157,8 +157,7 @@
     "@types/node": {
       "version": "14.14.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.2.tgz",
-      "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==",
-      "dev": true
+      "integrity": "sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg=="
     },
     "@types/uuid": {
       "version": "8.3.0",
@@ -171,6 +170,14 @@
       "integrity": "sha512-BVGCztsypW8EYwJ+Hq+QNYiT/MUyCif0ouBH+flrY66O5W+KIXAMML6E/0fJpm7VjIzgangahl5S03bJJQGrZw==",
       "requires": {
         "winston": "*"
+      }
+    },
+    "@types/ws": {
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@types/ws/-/ws-7.4.5.tgz",
+      "integrity": "sha512-8mbDgtc8xpxDDem5Gwj76stBDJX35KQ3YBoayxlqUQcL5BZUthiqP/VQ4PQnLHqM4PmlbyO74t98eJpURO+gPA==",
+      "requires": {
+        "@types/node": "*"
       }
     },
     "ajv": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "prepare": "npm run build",
     "build": "tsc",
     "project": "npx tsc -p tsconfig.json",
+    "watch": "tsc --watch --project tsconfig.json",
     "prepublish": "tsc -p tsconfig.json && tsc -p tsconfig-cjs.json"
   },
   "main": "./dist/cjs/index.js",
@@ -30,6 +31,7 @@
     "@types/js-yaml": "^3.12.5",
     "@types/uuid": "^8.3.0",
     "@types/winston": "^2.4.4",
+    "@types/ws": "^7.4.5",
     "bcryptjs": "^2.4.0",
     "js-yaml": "^3.12.0",
     "longjohn": "^0.2.11",

--- a/src/EventUtil.ts
+++ b/src/EventUtil.ts
@@ -1,6 +1,8 @@
-import { TransportStream } from './TransportStream';
+import { StreamType } from './TransportStream';
 
 const sty = require('sty');
+
+type EventUtilReturn = (message: string) => void;
 
 /**
  * Helper methods for colored output during input-events
@@ -11,8 +13,10 @@ export class EventUtil {
 	 * @param {net.Socket} socket
 	 * @return {function (string)}
 	 */
-	static genWrite(socket: TransportStream) {
-		return (string: string) => socket.write(sty.parse(string));
+	static genWrite(socket: StreamType | null): EventUtilReturn {
+		return socket
+			? (string: string) => socket.write(sty.parse(string))
+			: (string: string) => {};
 	}
 
 	/**
@@ -20,7 +24,9 @@ export class EventUtil {
 	 * @param {net.Socket} socket
 	 * @return {function (string)}
 	 */
-	static genSay(socket: TransportStream) {
-		return (string: string) => socket.write(sty.parse(string + '\r\n'));
+	static genSay(socket: StreamType | null): EventUtilReturn {
+		return socket
+			? (string: string) => socket.write(sty.parse(string + '\r\n'))
+			: (string: string) => {};
 	}
 }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -1,7 +1,3 @@
-'use strict';
-
-import { TelnetStream } from '../types/TelnetStream';
-import { WebsocketStream } from '../types/WebsocketStream';
 import { Account } from './Account';
 import { Character, ICharacterConfig, ISerializedCharacter } from './Character';
 import { CommandQueue, ICommandExecutable } from './CommandQueue';
@@ -14,6 +10,7 @@ import { Metadata } from './Metadatable';
 import { PlayerRoles } from './PlayerRoles';
 import { QuestTracker, SerializedQuestTracker } from './QuestTracker';
 import { Room } from './Room';
+import { StreamType } from './TransportStream';
 
 export interface IPlayerDef extends ICharacterConfig {
 	account: Account;
@@ -21,7 +18,7 @@ export interface IPlayerDef extends ICharacterConfig {
 	experience: number;
 	password: string;
 	prompt: string;
-	socket: TelnetStream | WebsocketStream | null;
+	socket: StreamType | null;
 	quests: SerializedQuestTracker;
 	role: PlayerRoles | number;
 }
@@ -59,7 +56,7 @@ export class Player extends Character {
 	password: string;
 	prompt: string;
 	questTracker: QuestTracker;
-	socket: TelnetStream | WebsocketStream | null;
+	socket: StreamType | null;
 	role: PlayerRoles | number;
 
 	__hydrated: boolean = false;
@@ -246,7 +243,7 @@ export class Player extends Character {
 			const eqDefs = this.__equipment as Record<string, IItemDef>;
 			this.equipment = new Map();
 			for (const slot in eqDefs) {
-				const itemDef= eqDefs[slot];
+				const itemDef = eqDefs[slot];
 				try {
 					const entityReference = itemDef.entityReference;
 					const area = itemDef.area ?? itemDef.entityReference.split(':')[0];
@@ -254,12 +251,12 @@ export class Player extends Character {
 						state.AreaManager.getArea(area),
 						entityReference
 					);
-					
+
 					const inventory = itemDef.inventory;
 					if (inventory) {
 						newItem.initializeInventoryFromSerialized(itemDef.inventory);
 					}
-					
+
 					newItem.hydrate(state, itemDef);
 					state.ItemManager.add(newItem);
 					this.equip(newItem, slot);
@@ -281,9 +278,8 @@ export class Player extends Character {
 				Logger.error(
 					`ERROR: Player ${this.name} was saved to invalid room ${this.room}.`
 				);
-				room = state.AreaManager.getPlaceholderArea().getRoomById(
-					'placeholder'
-				);
+				room =
+					state.AreaManager.getPlaceholderArea().getRoomById('placeholder');
 			}
 
 			this.room = room;

--- a/src/TransportStream.ts
+++ b/src/TransportStream.ts
@@ -1,14 +1,16 @@
 import { EventEmitter } from 'events';
 import { TelnetStream } from '../types/TelnetStream';
+import { TelnetSocket } from '../types/TelnetSocket';
+import { RanvierWebSocket } from '../types/RanvierWebSocket';
 import { WebsocketStream } from '../types/WebsocketStream';
 
-export type SocketType = TelnetStream | WebsocketStream;
-
+export type StreamType = TelnetStream | WebsocketStream;
+export type SocketType = TelnetSocket | RanvierWebSocket;
 /**
  * Base class for anything that should be sending or receiving data from the player
  */
 export class TransportStream extends EventEmitter {
-	socket?: TelnetStream | WebsocketStream;
+	socket?: SocketType;
 	_prompted: boolean = false;
 
 	get readable() {
@@ -37,7 +39,7 @@ export class TransportStream extends EventEmitter {
 
 		const methodName = 'execute' + command[0].toUpperCase() + command.substr(1);
 		if (typeof this[methodName as K] === 'function') {
-			const commandMethod = (this[methodName as K] as unknown) as (
+			const commandMethod = this[methodName as K] as unknown as (
 				...args: any[]
 			) => any;
 			return commandMethod.call(this, ...args);
@@ -72,7 +74,7 @@ export class TransportStream extends EventEmitter {
 	 * Attach a socket to this stream
 	 * @param {*} socket
 	 */
-	attach(socket: TelnetStream | WebsocketStream) {
+	attach(socket: SocketType) {
 		this.socket = socket;
 
 		this.socket.on('close', (_?: any) => {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,15 +1,13 @@
 {
-  "compilerOptions": {
-    "module": "es2020",
-    "target": "es2017",
-    "declaration": true,
-    "outDir": "./dist/esm",
-    "noImplicitAny": true,
-    "strict": true,
-    "esModuleInterop": true,
-    "sourceMap": true,
-  },
-  "include": [
-    "src/**/*"
-  ]
+	"compilerOptions": {
+		"module": "es2020",
+		"target": "es2017",
+		"declaration": true,
+		"outDir": "./dist/esm",
+		"noImplicitAny": true,
+		"strict": true,
+		"esModuleInterop": true,
+		"sourceMap": true
+	},
+	"include": ["src/**/*"]
 }

--- a/types/RanvierWebSocket.d.ts
+++ b/types/RanvierWebSocket.d.ts
@@ -1,0 +1,27 @@
+import { EventEmitter } from 'events';
+import WebSocket from 'ws';
+
+export declare class RanvierWebSocket extends EventEmitter {
+	socket: WebSocket | null;
+	echoing: boolean;
+	ended: boolean;
+	finished: boolean;
+	fresh: boolean;
+	readyState: number;
+	readable: boolean;
+	writable: boolean;
+
+	constructor();
+
+	attach(connection: WebSocket): void;
+
+	write(message: string): void;
+
+	pause(): void;
+
+	resume(): void;
+
+	end(): void;
+
+	executeSendData(group: string, data: any): void;
+}

--- a/types/WebsocketStream.d.ts
+++ b/types/WebsocketStream.d.ts
@@ -4,7 +4,7 @@ import { TransportStream } from '../src/TransportStream';
  * Essentially we want to look at the methods of WebSocket and match them to the appropriate methods on TransportStream
  */
 export declare class WebsocketStream extends TransportStream {
-	attach(socket: WebsocketStream): void;
+	attach(socket: any): void;
 
 	write(message: string): void;
 


### PR DESCRIPTION
Hard to do this with just core, being that telnetserver/telnetsocket and websocketserver/websocket aren't in the repo and offered as a bundle. But added some base classes and updated as best I could. 

Updated EventUtil as well to account for null as the player.socket can accept the type null and can be the case that a player instance exists without a socket. Makes sense to handle in that EventUtil. 

This setup is pretty much what I have in my game, but thought I could PR it into this repo. Let me know if there is anything better we can do, but it might be a good next step to have this in.