### PR TITLE
Bugfixes around hydration; extra deps removal

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -224,7 +224,7 @@
     },
     "async": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/async/-/async-1.0.0.tgz",
       "integrity": "sha1-+PwEyjoTeErenhZBr5hXjPvWR6k="
     },
     "asynckit": {
@@ -285,11 +285,6 @@
       "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
       "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
       "dev": true
-    },
-    "buffer-from": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-      "integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -374,7 +369,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -791,14 +786,6 @@
       "integrity": "sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==",
       "dev": true
     },
-    "longjohn": {
-      "version": "0.2.12",
-      "resolved": "https://registry.npmjs.org/longjohn/-/longjohn-0.2.12.tgz",
-      "integrity": "sha1-fKdEawg2VcN351EiE9x1TVKmSn4=",
-      "requires": {
-        "source-map-support": "0.3.2 - 1.0.0"
-      }
-    },
     "mime-db": {
       "version": "1.37.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.37.0.tgz",
@@ -825,13 +812,13 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -2188,7 +2175,7 @@
     },
     "path-is-absolute": {
       "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
       "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
       "dev": true
     },
@@ -2299,20 +2286,6 @@
       "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
       "dev": true
     },
-    "source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-    },
-    "source-map-support": {
-      "version": "0.5.9",
-      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.9.tgz",
-      "integrity": "sha512-gR6Rw4MvUlYy83vP0vxoVNzM6t8MUXqNuRsuBmBHQDu1Fh6X015FrLdgoDKcNdkwGubozq0P4N0Q37UyFVr1EA==",
-      "requires": {
-        "buffer-from": "^1.0.0",
-        "source-map": "^0.6.0"
-      }
-    },
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
@@ -2357,7 +2330,7 @@
     },
     "strip-ansi": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
       "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
       "requires": {
         "ansi-regex": "^2.0.0"
@@ -2473,7 +2446,7 @@
     },
     "wrap-ansi": {
       "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
+      "resolved": "http://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "requires": {
         "string-width": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@types/winston": "^2.4.4",
     "bcryptjs": "^2.4.0",
     "js-yaml": "^3.12.0",
-    "longjohn": "^0.2.11",
     "pretty-error": "^2.0.2",
     "require-dir": "^1.1.0",
     "sty": "",

--- a/src/EffectList.ts
+++ b/src/EffectList.ts
@@ -99,7 +99,7 @@ export class EffectList {
 					continue;
 				}
 				effect.state.lastTick = now;
-				if (!effect.state.ticks) {
+				if (!effect.state.ticks && effect.state.ticks !== 0) {
 					effect.state.ticks = 0;
 				}
 				effect.state.ticks++;

--- a/src/Item.ts
+++ b/src/Item.ts
@@ -278,6 +278,7 @@ export class Item extends GameEntity {
 		}
 
 		this.__manager = state.ItemManager;
+		super.hydrate(state, serialized);
 
 		state.ItemManager.add(this);
 

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -64,7 +64,6 @@ export class Logger {
 	}
 
 	static enablePrettyErrors() {
-		const longjohn = require('longjohn');
 		const pe = require('pretty-error').start();
 		pe.skipNodeFiles(); // Ignore native node files in stacktrace.
 	}

--- a/src/Logger.ts
+++ b/src/Logger.ts
@@ -68,4 +68,6 @@ export class Logger {
 		const pe = require('pretty-error').start();
 		pe.skipNodeFiles(); // Ignore native node files in stacktrace.
 	}
+
+	static get _winston () { return winston; }
 }

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -276,11 +276,18 @@ export class Player extends Character {
 		}
 
 		if (typeof this.room === 'string') {
-			let room = state.RoomManager.getRoom(this.room);
+			let room;
+			try {
+				room = state.RoomManager.getRoom(this.room);
+			} catch (e) {
+				Logger.error(e);
+			}
+
 			if (!room) {
 				Logger.error(
 					`ERROR: Player ${this.name} was saved to invalid room ${this.room}.`
 				);
+
 				room = state.AreaManager.getPlaceholderArea().getRoomById(
 					'placeholder'
 				);


### PR DESCRIPTION
Cleaning up a couple of small issues that caused bugs or involved unused deps.

1.  Longjohn is no longer used by default; I removed the dep from core and added a getter so the user can get the instance of winston used by core and customize logging on their end.
2.  Items needed to call super.hydrate in their hydrate method to take advantage of all of the benefits of extending GameEntity. This caused issues with equipment behaviors after persisting equipment to a player, logging off and back on to re-hydrate it.
3. Since RoomManager.getRoom throws an error on failure, I had to wrap the call to it in Player.hydrate in a try/catch instead of relying on a null check. This allowed the placeholder behavior to work as intended instead of throwing an error and crashing the server.