### PR TITLE
Improves types to server events.

### DIFF
--- a/src/GameServer.ts
+++ b/src/GameServer.ts
@@ -1,11 +1,13 @@
 import { EventEmitter } from 'events';
+import { IGameState } from './GameState';
+import { CommanderStatic } from 'commander';
 
 export class GameServer extends EventEmitter {
 	/**
 	 * @param {commander} commander
 	 * @fires GameServer#startup
 	 */
-	startup(commander: object) {
+	startup(commander: CommanderStatic) {
 		/**
 		 * @event GameServer#startup
 		 * @param {commander} commander
@@ -22,4 +24,11 @@ export class GameServer extends EventEmitter {
 		 */
 		this.emit('shutdown');
 	}
+}
+
+export interface IGameServerEvent {
+    listeners: {
+        shutdown?: (state: IGameState) => () => void;
+        startup?: (state: IGameState) => (commander: CommanderStatic) => void;
+    };
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,8 @@
 		"noImplicitAny": true,
 		"strict": true,
 		"esModuleInterop": true,
-		"sourceMap": true
+		"sourceMap": true,
+		"moduleResolution": "node"
 	},
 	"include": ["src/**/*"]
 }


### PR DESCRIPTION
Fills in Commander type in 'startup' listener. Adds the basic listener interface for the GameServer events.

Able to use interface for custom `server-events` files as well as fits the standard 'telnet-neworking>telnet-server' server-event

```
export default (): IGameServerEvent => {
    return {
        listeners: {
            startup: (state) => (com) => {
                // code executed on startup here
            }
        }
    }
}

```