### PR TITLE
convert EntityFactory to abstract class

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
 	"bugs": "https://github.com/Ranvier-TS/core-ts/issues",
 	"license": "MIT",
 	"author": "Shawn Biddle (http://shawnbiddle.com), Sean O'Donohue, Brian Nelson",
-	"version": "3.2.1",
+	"version": "3.2.2",
 	"repository": "github:ranvier-ts/core-ts",
 	"engines": {
 		"node": ">= 12.18.2"

--- a/src/EntityFactory.ts
+++ b/src/EntityFactory.ts
@@ -22,7 +22,7 @@ type EntityConstructor<TEntity, TDef extends EntityDefinitionBase> = new (
 /**
  * Stores definitions of entities to allow for easy creation/cloning
  */
-export class EntityFactory<
+export abstract class EntityFactory<
 	TEntity extends EffectableEntity,
 	TDef extends EntityDefinitionBase
 > {


### PR DESCRIPTION
With new types, we should enforce not creating an instance of base class EntityFactory as it should be extended to use properly.