### PR TITLE
fix: prompt tokens, roomDesc, command categories, quest fixes, and more

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,5 +8,5 @@
 !index.d.ts
 !types/*
 !package*
-!dist/*
+!dist/**
 !tsconfig.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
 	"name": "ranvier",
-	"version": "3.1.1",
+	"version": "3.2.2",
 	"lockfileVersion": 2,
 	"requires": true,
 	"packages": {
 		"": {
 			"name": "ranvier",
-			"version": "3.1.1",
+			"version": "3.2.2",
 			"license": "MIT",
 			"dependencies": {
 				"@types/bcryptjs": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
 	"scripts": {
 		"test": "nyc --reporter=html --reporter=text --include=src --all mocha --recursive",
 		"coverage": "nyc report --reporter=text-lcov | coveralls",
-		"prepare": "npm run build",
+		"prepare": "tsc && tsc -p tsconfig-cjs.json",
 		"build": "tsc",
 		"project": "npx tsc -p tsconfig.json",
 		"watch": "tsc --watch --project tsconfig.json",

--- a/src/AccountManager.ts
+++ b/src/AccountManager.ts
@@ -29,6 +29,7 @@ export class AccountManager {
 	 * @param {Account} account
 	 */
 	addAccount(account: Account) {
+		account.__manager = this;
 		this.accounts.set(account.username, account);
 	}
 

--- a/src/Broadcast.ts
+++ b/src/Broadcast.ts
@@ -188,37 +188,29 @@ export class Broadcast {
 		}
 
 		player.socket._prompted = false;
+
+		// If there are extra prompts (stats, combat), skip the bare prompt string
+		if (player.extraPrompts.size > 0) {
+			for (const [id, extraPrompt] of player.extraPrompts) {
+				Broadcast.sayAt(
+					player as Broadcastable,
+					extraPrompt.renderer(),
+					wrapWidth,
+					useColor
+				);
+				if (extraPrompt.removeOnRender) {
+					player.removePrompt(id);
+				}
+			}
+			return;
+		}
+
 		Broadcast.at(
 			player as Broadcastable,
 			'\r\n' + player.interpolatePrompt(player.prompt, extra) + ' ',
 			wrapWidth,
 			useColor
 		);
-		let needsNewline = player.extraPrompts.size > 0;
-		if (needsNewline) {
-			Broadcast.sayAt(player as Broadcastable);
-		}
-
-		for (const [id, extraPrompt] of player.extraPrompts) {
-			Broadcast.sayAt(
-				player as Broadcastable,
-				extraPrompt.renderer(),
-				wrapWidth,
-				useColor
-			);
-			if (extraPrompt.removeOnRender) {
-				player.removePrompt(id);
-			}
-		}
-
-		if (needsNewline) {
-			Broadcast.at(player as Broadcastable, '> ');
-		}
-
-		player.socket._prompted = true;
-		if (player.socket.writable) {
-			player.socket.command('goAhead');
-		}
 	}
 
 	/**

--- a/src/Broadcast.ts
+++ b/src/Broadcast.ts
@@ -202,6 +202,7 @@ export class Broadcast {
 					player.removePrompt(id);
 				}
 			}
+			player.socket._prompted = true;
 			return;
 		}
 
@@ -211,6 +212,7 @@ export class Broadcast {
 			wrapWidth,
 			useColor
 		);
+		player.socket._prompted = true;
 	}
 
 	/**

--- a/src/Broadcast.ts
+++ b/src/Broadcast.ts
@@ -223,6 +223,7 @@ export class Broadcast {
 	 * @param {string} barChar Character to use for the current progress
 	 * @param {string} fillChar Character to use for the rest
 	 * @param {string} delimiters Characters to wrap the bar in
+	 * @param {string} tipChar Character for the progress tip (default `>`)
 	 * @return {string}
 	 */
 	static progress(
@@ -231,7 +232,8 @@ export class Broadcast {
 		color: string,
 		barChar: string = '#',
 		fillChar: string = ' ',
-		delimiters: string = '()'
+		delimiters: string = '()',
+		tipChar: string = '>'
 	) {
 		percent = Math.max(0, percent);
 		width -= 3; // account for delimiters and tip of bar
@@ -247,7 +249,7 @@ export class Broadcast {
 		const widthPercent = Math.round((percent / 100) * width);
 		buf +=
 			Broadcast.line(widthPercent, barChar) +
-			(percent === 100 ? '' : rightDelim);
+			(percent === 100 ? '' : tipChar);
 		buf += Broadcast.line(width - widthPercent, fillChar);
 		buf += '</bold>' + rightDelim + closeColor;
 		return buf;

--- a/src/BundleManager.ts
+++ b/src/BundleManager.ts
@@ -561,7 +561,7 @@ export class BundleManager {
 		const records = await loader.fetchAll();
 		for (const helpName in records) {
 			try {
-				const hfile = new Helpfile(bundle, helpName, records[helpName].doc);
+				const hfile = new Helpfile(bundle, helpName, records[helpName]);
 
 				const command =
 					hfile.command && this.state.CommandManager.get(hfile.command);

--- a/src/BundleManager.ts
+++ b/src/BundleManager.ts
@@ -710,6 +710,7 @@ export class BundleManager {
 
 			Logger.verbose(`\t\t${skillName}`);
 			const skill = new Skill(skillName, skillImport, this.state);
+			skill.source = skillPath;
 
 			if (skill.type === SkillType.SKILL) {
 				this.state.SkillManager.add(skill);

--- a/src/Channel.ts
+++ b/src/Channel.ts
@@ -139,14 +139,7 @@ export class Channel {
 			}
 			if (!message.length) {
 				throw new NoMessageError();
-			}
-
-			const target = targets[0];
-
-			Broadcast.sayAt(
-				sender,
-				this.formatter.sender(sender, target, message, this.colorify.bind(this))
-			);
+			}		
 		} else {
 			Broadcast.sayAt(
 				sender,

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -12,6 +12,8 @@ export interface ICommandDef {
 	requiredRole?: PlayerRoles;
 	metadata?: Record<string, any>;
 	command: Function;
+	category?: string;
+	displayAs?: string;
 }
 
 /**
@@ -35,6 +37,8 @@ export class Command {
 	requiredRole: PlayerRoles;
 	file: string;
 	metadata: Record<string, any>;
+	category: string;
+	displayAs: string;
 
 	/**
 	 * @param {string} bundle Bundle the command came from
@@ -57,6 +61,8 @@ export class Command {
 		this.requiredRole = def.requiredRole || PlayerRoles.PLAYER;
 		this.file = file;
 		this.metadata = def.metadata || {};
+		this.category = def.category || 'sistema';
+		this.displayAs = def.displayAs || this.name;
 	}
 
 	/**

--- a/src/Command.ts
+++ b/src/Command.ts
@@ -61,7 +61,7 @@ export class Command {
 		this.requiredRole = def.requiredRole || PlayerRoles.PLAYER;
 		this.file = file;
 		this.metadata = def.metadata || {};
-		this.category = def.category || 'sistema';
+		this.category = def.category || 'general';
 		this.displayAs = def.displayAs || this.name;
 	}
 

--- a/src/CommandManager.ts
+++ b/src/CommandManager.ts
@@ -46,10 +46,18 @@ export class CommandManager {
 	 * @return {Command}
 	 */
 	find(search: string, returnAlias?: boolean) {
+		let best: Command | undefined;
+		let bestName: string | undefined;
+
 		for (const [name, command] of this.commands.entries()) {
 			if (name.indexOf(search) === 0) {
-				return returnAlias ? { command, alias: name } : command;
+				if (!best || command.requiredRole < best.requiredRole) {
+					best = command;
+					bestName = name;
+				}
 			}
 		}
+
+		return returnAlias ? (best ? { command: best, alias: bestName! } : undefined) : best;
 	}
 }

--- a/src/Config.ts
+++ b/src/Config.ts
@@ -18,4 +18,11 @@ export class Config {
 	static load(data: object) {
 		__cache = data;
 	}
+
+	/**
+	 * Set a config value at runtime
+	 */
+	static set(key: string, value: any) {
+		__cache[key] = value;
+	}
 }

--- a/src/EffectFactory.ts
+++ b/src/EffectFactory.ts
@@ -69,6 +69,10 @@ export class EffectFactory {
 		let def = Object.assign({}, entry.definition);
 		def.config = Object.assign(def.config || {}, config || {});
 		def.state = Object.assign(def.state || {}, state || {});
+		// Convert -1 to Infinity for runtime (serialization handles the reverse)
+		if (def.config.duration === -1) {
+			def.config.duration = Infinity;
+		}
 		const effect = new Effect(id, def);
 		entry.eventManager.attach(effect);
 

--- a/src/EffectList.ts
+++ b/src/EffectList.ts
@@ -155,6 +155,7 @@ export class EffectList {
 
 		this.effects.add(effect);
 		effect.target = this.target;
+		effect.activate();
 
 		/**
 		 * @event Effect#effectAdded

--- a/src/HelpManager.ts
+++ b/src/HelpManager.ts
@@ -81,6 +81,13 @@ export class HelpManager {
 			return null;
 		}
 
+		// Prefer name-prefix match over keyword/alias match
+		for (const [name, hfile] of results) {
+			if (name.indexOf(help) === 0) {
+				return hfile;
+			}
+		}
+
 		const [_, hfile] = [...results][0];
 
 		return hfile;

--- a/src/Item.ts
+++ b/src/Item.ts
@@ -308,11 +308,8 @@ export class Item extends GameEntity {
 			this.area = state.AreaManager.getArea(this.area);
 		}
 
-		// if the item was saved with a custom inventory hydrate it
-		if (this.inventory) {
-			this.inventory.hydrate(state, this);
-		} else {
-			// otherwise load its default inv
+		// Load default items from YAML definition (fresh spawn, not deserialized)
+		if (!serialized && this.defaultItems.length > 0) {
 			this.defaultItems.forEach((defaultItemId: IItemDef | string) => {
 				if (typeof defaultItemId == 'string') {
 					Logger.verbose(
@@ -324,6 +321,11 @@ export class Item extends GameEntity {
 					this.addItem(newItem);
 				}
 			});
+		}
+
+		// Hydrate serialized inventory (restored from player save)
+		if (this.inventory) {
+			this.inventory.hydrate(state, this);
 		}
 	}
 

--- a/src/Npc.ts
+++ b/src/Npc.ts
@@ -20,6 +20,7 @@ export interface INpcDef extends ICharacterConfig, EntityDefinitionBase {
 	entityReference: EntityReference;
 	keywords: string[];
 	quests?: EntityReference[];
+	roomDesc?: string;
 	uuid?: string;
 }
 
@@ -33,6 +34,7 @@ export class Npc extends Character {
 	entityReference: EntityReference;
 	id: number | string;
 	quests: EntityReference[];
+	roomDesc: string;
 	uuid: string;
 	commandQueue: CommandQueue;
 	keywords: string[];
@@ -61,6 +63,7 @@ export class Npc extends Character {
 		this.entityReference = data.entityReference;
 		this.keywords = data.keywords;
 		this.id = data.id;
+		this.roomDesc = data.roomDesc || data.name;
 
 		this.quests = data.quests || [];
 

--- a/src/Party.ts
+++ b/src/Party.ts
@@ -6,6 +6,7 @@ import { PlayerOrNpc } from './GameEntity';
 export class Party extends Set<PlayerOrNpc> {
 	invited: Set<PlayerOrNpc>;
 	leader: PlayerOrNpc;
+	name?: string;
 	constructor(leader: PlayerOrNpc) {
 		super();
 		this.invited = new Set();
@@ -16,6 +17,7 @@ export class Party extends Set<PlayerOrNpc> {
 	delete(member: PlayerOrNpc) {
 		const deleted = super.delete(member);
 		member.party = null;
+		member.unfollow();
 		return deleted;
 	}
 
@@ -28,7 +30,9 @@ export class Party extends Set<PlayerOrNpc> {
 
 	disband() {
 		for (const member of this) {
-			this.delete(member);
+			member.unfollow();
+			super.delete(member);
+			member.party = null;
 		}
 	}
 

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -137,8 +137,22 @@ export class Player extends Character {
 		}
 		const promptData = Object.assign(attributeData, extraData);
 
+		// Short aliases for common prompt tokens
+		const pd = promptData as any;
+		pd.h = pd.health?.current;
+		pd.H = pd.health?.max;
+		pd.m = pd.mana?.current;
+		pd.M = pd.mana?.max;
+		pd.v = pd.energy?.current;
+		pd.V = pd.energy?.max;
+		pd.x = pd.experience;
+		pd.t = pd.tnl;
+		pd.l = pd.level;
+		pd.g = pd.gold;
+		pd.n = pd.target?.name;
+
 		let matches = null;
-		while ((matches = promptStr.match(/%([a-z\.]+)%/))) {
+		while ((matches = promptStr.match(/%([a-zA-Z\.]+)%/))) {
 			const token = matches[1];
 			let promptValue: any = token
 				.split('.')

--- a/src/Player.ts
+++ b/src/Player.ts
@@ -150,22 +150,20 @@ export class Player extends Character {
 		pd.l = pd.level;
 		pd.g = pd.gold;
 		pd.n = pd.target?.name;
+		pd.a = pd.target?.health?.current;
+		pd.A = pd.target?.health?.max;
+		pd.N = this.name;
 
-		let matches = null;
-		while ((matches = promptStr.match(/%([a-zA-Z\.]+)%/))) {
-			const token = matches[1];
-			let promptValue: any = token
-				.split('.')
-				.reduce(
-					(obj, index) => obj && (obj[index] as typeof promptData),
-					promptData
-				);
-
-			if (promptValue === null || promptValue === undefined) {
-				(promptValue as string) = 'invalid-token';
+		promptStr = promptStr.replace(
+			/%([a-zA-Z])/g,
+			(match, token) => {
+				let promptValue = promptData[token];
+				if (promptValue === null || promptValue === undefined) {
+					promptValue = 'invalid-token';
+				}
+				return promptValue as string;
 			}
-			promptStr = promptStr.replace(matches[0], promptValue as string);
-		}
+		);
 
 		return promptStr;
 	}

--- a/src/PlayerManager.ts
+++ b/src/PlayerManager.ts
@@ -65,6 +65,7 @@ export class PlayerManager extends EventEmitter {
 			player.socket?.end();
 		}
 
+		player.emit('logout');
 		player.removeAllListeners();
 		player.removeFromCombat();
 		player.effects.clear();

--- a/src/PlayerRoles.ts
+++ b/src/PlayerRoles.ts
@@ -2,6 +2,7 @@ export const PlayerRoles = {
 	ADMIN: 2,
 	BUILDER: 1,
 	PLAYER: 0,
+	OWNER: 3,
 } as const;
 
 export type PlayerRoles = typeof PlayerRoles[keyof typeof PlayerRoles];

--- a/src/Quest.ts
+++ b/src/Quest.ts
@@ -168,6 +168,8 @@ export class Quest extends EventEmitter {
 
 	hydrate() {
 		(this.state as ISerializedQuestGoal[]).forEach((goalState, i: number) => {
+			// Skip if goal was removed from YAML config (saved state mismatch)
+			if (!this.goals[i]) return;
 			this.goals[i].hydrate(goalState.state);
 		});
 	}

--- a/src/QuestFactory.ts
+++ b/src/QuestFactory.ts
@@ -84,10 +84,11 @@ export class QuestFactory {
 		player: Player,
 		state: ISerializedQuestDef[] = []
 	) {
-		const quest = this.quests.get(qid);
-		if (!quest) {
-			throw new Error(`Trying to create invalid quest id [${qid}]`);
-		}
+	const quest = this.quests.get(qid);
+	if (!quest) {
+		Logger.warn(`QuestFactory: invalid quest id [${qid}], skipping`);
+		return null;
+	}
 
 		const instance = new Quest(GameState, quest.id, quest.config, player);
 		instance.state = state;

--- a/src/QuestFactory.ts
+++ b/src/QuestFactory.ts
@@ -66,9 +66,12 @@ export class QuestFactory {
 			return true;
 		}
 
-		return quest.config.requires.every((requiresRef) =>
-			tracker.isComplete(requiresRef)
-		);
+		return quest.config.requires.every((requiresRef) => {
+			if (typeof requiresRef === 'string' && requiresRef.startsWith('level:')) {
+				return player.level >= parseInt(requiresRef.split(':')[1], 10);
+			}
+			return tracker.isComplete(requiresRef);
+		});
 	}
 
 	/**

--- a/src/QuestTracker.ts
+++ b/src/QuestTracker.ts
@@ -123,6 +123,10 @@ export class QuestTracker {
 				this.player,
 				(data.state as ISerializedQuestDef[])
 			);
+			if (!quest) {
+				this.activeQuests.delete(qid);
+				continue;
+			}
 			quest.started = data.started;
 			quest.hydrate();
 

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -33,6 +33,7 @@ export interface IRoomDef extends EntityDefinitionBase {
 	attributes?: SerializedAttributes;
 	effects?: ISerializedEffect[];
 	coordinates?: [number, number, number];
+	sector?: string;
 	doors?: Record<string, IDoor>;
 	exits?: IExit[];
 	metadata?: Record<string, any>;

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -248,7 +248,7 @@ export class Room extends GameEntity {
 			}
 		);
 
-		if (!this.area || !this.coordinates) {
+		if (!this.area || !this.coordinates || this.area.metadata.noInferExits) {
 			return exits;
 		}
 

--- a/src/Room.ts
+++ b/src/Room.ts
@@ -304,6 +304,12 @@ export class Room extends GameEntity {
 			return false;
 		}
 
+		// Exact match first — prevents "south" matching "southwest"
+		const exact = exits.find(
+			(ex: IExit) => ex.direction === exitName
+		);
+		if (exact) return exact;
+
 		const roomExit = exits.find(
 			(ex: IExit) => ex.direction.indexOf(exitName) === 0
 		);

--- a/src/Skill.ts
+++ b/src/Skill.ts
@@ -68,6 +68,11 @@ export class Skill {
 	targetSelf: boolean;
 	type: SkillType;
 	/**
+	 * File path to the skill definition on disk, used for hot-reloading.
+	 */
+	source: string | null;
+
+	/**
 	 * @param {string} id
 	 * @param {object} config
 	 * @param {GameState} state
@@ -114,6 +119,7 @@ export class Skill {
 		this.targetSelf = targetSelf;
 		this.type = type;
 		this.getDamage = getDamage;
+		this.source = null;
 	}
 
 	/**

--- a/src/Skill.ts
+++ b/src/Skill.ts
@@ -26,6 +26,7 @@ export interface ISkillOptions {
 	targetSelf?: boolean;
 	type: SkillType;
 	options?: any;
+	getDamage?: (player: PlayerOrNpc) => number | null;
 }
 
 export interface ISkillCooldown {
@@ -54,6 +55,7 @@ export class Skill {
 	cooldownLength: ISkillCooldown | number | null;
 	effect: string | null;
 	flags: any[];
+	getDamage: ((player: PlayerOrNpc) => number | null) | null;
 	id: string;
 	info: Function;
 	initiatesCombat: boolean;
@@ -85,6 +87,7 @@ export class Skill {
 			targetSelf = false,
 			type = SkillType.SKILL,
 			options = {},
+			getDamage = null,
 		} = config;
 
 		this.configureEffect = configureEffect;
@@ -110,6 +113,7 @@ export class Skill {
 		this.state = state;
 		this.targetSelf = targetSelf;
 		this.type = type;
+		this.getDamage = getDamage;
 	}
 
 	/**

--- a/test/unit/Account.js
+++ b/test/unit/Account.js
@@ -1,0 +1,109 @@
+'use strict';
+
+const assert = require('assert');
+const { Account } = require('../../dist/cjs/Account');
+
+describe('Account', function () {
+  describe('#addCharacter', function () {
+    it('should add a character to the list', function () {
+      const account = new Account({ username: 'test' });
+      account.addCharacter('Foo');
+      assert.equal(account.characters.length, 1);
+      assert.equal(account.characters[0].username, 'Foo');
+      assert.equal(account.characters[0].deleted, false);
+    });
+
+    it('should allow multiple characters', function () {
+      const account = new Account({ username: 'test' });
+      account.addCharacter('Foo');
+      account.addCharacter('Bar');
+      assert.equal(account.characters.length, 2);
+    });
+  });
+
+  describe('#hasCharacter', function () {
+    it('should return true for existing character', function () {
+      const account = new Account({ username: 'test' });
+      account.addCharacter('Foo');
+      assert.ok(account.hasCharacter('Foo'));
+    });
+
+    it('should return false for missing character', function () {
+      const account = new Account({ username: 'test' });
+      assert.ok(!account.hasCharacter('Foo'));
+    });
+
+    it('should find deleted character by name (deleted flag is separate)', function () {
+      const account = new Account({ username: 'test' });
+      account.addCharacter('Foo');
+      account.deleteCharacter('Foo');
+      assert.ok(account.hasCharacter('Foo'));
+      assert.ok(account.characters[0].deleted);
+    });
+  });
+
+  describe('#setPassword', function () {
+    it('should hash the password', function () {
+      const account = new Account({ username: 'test' });
+      account.setPassword('secret123');
+      assert.ok(account.password);
+      assert.notEqual(account.password, 'secret123');
+    });
+
+    it('should call save()', function () {
+      const account = new Account({ username: 'test' });
+      let saved = false;
+      account.save = () => { saved = true; };
+      account.setPassword('secret123');
+      assert.ok(saved);
+    });
+  });
+
+  describe('#serialize', function () {
+    it('should return account data object', function () {
+      const account = new Account({
+        username: 'TestUser',
+        characters: [{ username: 'Foo', deleted: false }],
+        password: 'hash',
+        metadata: { email: 'a@b.com' },
+        banned: false,
+        deleted: false,
+      });
+      const data = account.serialize();
+      assert.equal(data.username, 'TestUser');
+      assert.equal(data.characters.length, 1);
+      assert.equal(data.metadata.email, 'a@b.com');
+      assert.equal(data.banned, false);
+      assert.equal(data.deleted, false);
+    });
+  });
+
+  describe('#save', function () {
+    it('should not crash when __manager is undefined', function () {
+      const account = new Account({ username: 'test' });
+      account.addCharacter('Foo');
+      account.save();  // should be a no-op, not throw
+    });
+
+    it('should call loader.update when __manager is set', function () {
+      const account = new Account({ username: 'TestSave' });
+      account.addCharacter('Foo');
+
+      let calledId = null;
+      let calledData = null;
+      account.__manager = {
+        loader: {
+          update: (id, data) => {
+            calledId = id;
+            calledData = data;
+          }
+        }
+      };
+
+      account.save();
+      assert.equal(calledId, 'TestSave');
+      assert.equal(calledData.username, 'TestSave');
+      assert.equal(calledData.characters.length, 1);
+    });
+  });
+});

--- a/test/unit/AccountManager.js
+++ b/test/unit/AccountManager.js
@@ -1,0 +1,105 @@
+'use strict';
+
+const assert = require('assert');
+const { AccountManager } = require('../../dist/cjs/AccountManager');
+const { Account } = require('../../dist/cjs/Account');
+
+describe('AccountManager', function () {
+  describe('#addAccount', function () {
+    it('should add account to the map', function () {
+      const manager = new AccountManager();
+      const account = new Account({ username: 'test' });
+      manager.addAccount(account);
+      const stored = manager.accounts.get('test');
+      assert.equal(stored, account);
+    });
+
+    it('should set __manager on the account', function () {
+      const manager = new AccountManager();
+      const account = new Account({ username: 'test' });
+      manager.addAccount(account);
+      assert.equal(account.__manager, manager);
+    });
+  });
+
+  describe('#getAccount', function () {
+    it('should return existing account', function () {
+      const manager = new AccountManager();
+      const account = new Account({ username: 'test' });
+      manager.addAccount(account);
+      assert.equal(manager.getAccount('test'), account);
+    });
+
+    it('should throw for missing account', function () {
+      const manager = new AccountManager();
+      assert.throws(() => manager.getAccount('nonexistent'), /can't find/);
+    });
+  });
+
+  describe('#setLoader', function () {
+    it('should store the loader reference', function () {
+      const manager = new AccountManager();
+      const loader = { fetch: () => {} };
+      manager.setLoader(loader);
+      assert.equal(manager.loader, loader);
+    });
+  });
+
+  describe('#loadAccount', function () {
+    it('should return cached account without fetching', async function () {
+      const manager = new AccountManager();
+      const account = new Account({ username: 'cached' });
+      manager.accounts.set('cached', account);
+
+      let fetched = false;
+      manager.loader = { fetch: async () => { fetched = true; return {}; } };
+
+      const result = await manager.loadAccount('cached');
+      assert.equal(result, account);
+      assert.ok(!fetched);
+    });
+
+    it('should fetch from loader when not cached', async function () {
+      const manager = new AccountManager();
+      let fetched = false;
+      manager.loader = {
+        fetch: async (username) => {
+          fetched = true;
+          return { username, metadata: {} };
+        }
+      };
+
+      const result = await manager.loadAccount('newuser');
+      assert.ok(fetched);
+      assert.equal(result.username, 'newuser');
+    });
+
+    it('should add loaded account to the manager', async function () {
+      const manager = new AccountManager();
+      manager.loader = {
+        fetch: async () => ({ username: 'loaded', metadata: {} })
+      };
+
+      const account = await manager.loadAccount('loaded');
+      assert.equal(manager.accounts.get('loaded'), account);
+    });
+
+    it('should set __manager on loaded accounts', async function () {
+      const manager = new AccountManager();
+      manager.loader = {
+        fetch: async () => ({ username: 'newbie', metadata: {} })
+      };
+
+      const account = await manager.loadAccount('newbie');
+      assert.equal(account.__manager, manager);
+    });
+
+    it('should throw when no loader configured', async function () {
+      const manager = new AccountManager();
+      await assert.rejects(
+        () => manager.loadAccount('any'),
+        /No entity loader/
+      );
+    });
+  });
+});

--- a/test/unit/Attribute.js
+++ b/test/unit/Attribute.js
@@ -1,11 +1,11 @@
 const assert = require('assert');
-const { Attribute } = require('../../src/Attribute');
+const { Attribute } = require('../../dist/cjs/Attribute');
 
 describe('Basic Attribute',  () => {
   let attribute = null;
   const base = 10;
   beforeEach(() => {
-    attribute = new Attribute('test', base);
+    attribute = new Attribute('test', base, 0);
   });
 
   describe('#setBase', () => {

--- a/test/unit/Broadcast.js
+++ b/test/unit/Broadcast.js
@@ -1,0 +1,102 @@
+'use strict';
+
+const { describe, it } = require('node:test');
+const assert = require('node:assert');
+const { Broadcast } = require('../../dist/cjs/Broadcast');
+
+const strip = s => s.replace(/<[^>]+>/g, '');
+
+describe('Broadcast.progress', () => {
+  it('produces correct visible width at 50%', () => {
+    const result = Broadcast.progress(25, 50, 'green');
+    assert.equal(strip(result).length, 25);
+  });
+
+  it('produces correct visible width at 0%', () => {
+    const result = Broadcast.progress(25, 0, 'red');
+    assert.equal(strip(result).length, 25);
+  });
+
+  it('produces correct visible width at 100%', () => {
+    const result = Broadcast.progress(25, 100, 'green');
+    assert.equal(strip(result).length, 25);
+  });
+
+  it('uses > as tip character at non-100%', () => {
+    const result = Broadcast.progress(15, 50, 'green');
+    const visible = strip(result);
+    assert.ok(visible.includes('>'), 'tip > should be present');
+  });
+
+  it('has no tip character at 100%', () => {
+    const result = Broadcast.progress(15, 100, 'green');
+    const visible = strip(result);
+    assert.ok(!visible.includes('>'), 'tip > should be absent at 100%');
+  });
+
+  it('renders full bar at 100%', () => {
+    const result = Broadcast.progress(25, 100, 'green');
+    const visible = strip(result);
+    assert.equal(visible.length, 25);
+    assert.equal(visible[0], '(');
+    assert.equal(visible[visible.length - 1], ')');
+    assert.ok(!visible.includes('>'));
+    // All interior chars should be #
+    for (let i = 1; i < visible.length - 1; i++) {
+      assert.equal(visible[i], '#');
+    }
+  });
+
+  it('renders empty bar at 0%', () => {
+    const result = Broadcast.progress(25, 0, 'red');
+    const visible = strip(result);
+    assert.equal(visible.length, 25);
+    assert.ok(visible.startsWith('(>'), 'should start with (> at 0%');
+  });
+
+  it('accepts custom delimiters', () => {
+    const result = Broadcast.progress(15, 50, 'green', '#', ' ', '[]');
+    assert.ok(result.includes('[<bold>'), 'should use [ as left delim');
+    assert.ok(result.endsWith(']</green>'), 'should end with ]');
+  });
+
+  it('accepts custom tipChar', () => {
+    const result = Broadcast.progress(15, 50, 'green', '#', ' ', '()', '*');
+    const visible = strip(result);
+    assert.ok(visible.includes('*'), 'custom tipChar * should be present');
+    assert.ok(!visible.includes('>'), 'default > should be absent');
+  });
+
+  it('clamps negative percent to 0', () => {
+    const result = Broadcast.progress(15, -10, 'red');
+    const visible = strip(result);
+    assert.equal(visible.length, 15);
+    assert.ok(visible.startsWith('(>'), 'negative percent should behave like 0%');
+  });
+
+  it('wraps bar in color tags', () => {
+    const result = Broadcast.progress(15, 50, 'cyan');
+    assert.ok(result.startsWith('<cyan>'), 'should start with <cyan>');
+    assert.ok(result.endsWith('</cyan>'), 'should end with </cyan>');
+  });
+
+  it('wraps filled portion in bold tags', () => {
+    const result = Broadcast.progress(15, 50, 'green');
+    assert.ok(result.includes('<bold>'), 'should have <bold>');
+    assert.ok(result.includes('</bold>'), 'should have </bold>');
+  });
+});
+
+describe('Broadcast.line', () => {
+  it('creates repeated characters', () => {
+    assert.equal(Broadcast.line(5, '#'), '#####');
+  });
+
+  it('defaults to dash', () => {
+    assert.equal(Broadcast.line(3), '---');
+  });
+
+  it('wraps in color tags when specified', () => {
+    assert.equal(Broadcast.line(3, '#', 'red'), '<red>###</red>');
+  });
+});

--- a/test/unit/CommandQueue.js
+++ b/test/unit/CommandQueue.js
@@ -1,5 +1,5 @@
 const assert = require('assert');
-const CommandQueue = require('../../src/CommandQueue');
+const { CommandQueue } = require('../../dist/cjs/CommandQueue');
 
 describe('Command Queue',  function () {
   let queue = null;

--- a/tests/quest-factory.test.js
+++ b/tests/quest-factory.test.js
@@ -1,0 +1,113 @@
+'use strict';
+
+const { describe, it, before } = require('node:test');
+const assert = require('node:assert/strict');
+const { QuestFactory } = require('../dist/cjs/QuestFactory');
+
+function makePlayer(level, opts = {}) {
+  return {
+    level,
+    questTracker: {
+      completedQuests: new Map(opts.completed || []),
+      activeQuests: new Map(),
+      isActive(ref) { return (opts.active || []).includes(ref); },
+      isComplete(ref) { return (opts.completed || []).some(([k]) => k === ref); },
+    },
+  };
+}
+
+let factory;
+
+before(() => {
+  factory = new QuestFactory();
+  factory.add('heragon', 'quest_a', {
+    id: 'quest_a', title: 'Quest A', level: 1, rewards: [], goals: [],
+  });
+  factory.add('heragon', 'quest_b', {
+    id: 'quest_b', title: 'Quest B', level: 1,
+    requires: ['heragon:quest_a'], rewards: [], goals: [],
+  });
+  factory.add('heragon', 'quest_level_3', {
+    id: 'quest_level_3', title: 'Quest Lv 3', level: 1,
+    requires: ['heragon:quest_a', 'level:3'], rewards: [], goals: [],
+  });
+  factory.add('heragon', 'quest_level_5', {
+    id: 'quest_level_5', title: 'Quest Lv 5', level: 1,
+    requires: ['level:5'], rewards: [], goals: [],
+  });
+  factory.add('heragon', 'repeatable', {
+    id: 'repeatable', title: 'Repeatable', level: 1,
+    repeatable: true, rewards: [], goals: [],
+  });
+  factory.add('heragon', 'quest_no_req', {
+    id: 'quest_no_req', title: 'No Req', level: 1, rewards: [], goals: [],
+  });
+});
+
+// ---- Backward compatibility (senza level:) ----
+
+describe('canStart — backward compatibility', () => {
+  it('quest senza requires — start consentito', () => {
+    const p = makePlayer(5);
+    assert.ok(factory.canStart(p, 'heragon:quest_no_req'));
+  });
+
+  it('quest con requires quest completata — start consentito', () => {
+    const p = makePlayer(5, { completed: [['heragon:quest_a', {}]] });
+    assert.ok(factory.canStart(p, 'heragon:quest_b'));
+  });
+
+  it('quest con requires quest NON completata — start negato', () => {
+    const p = makePlayer(5);
+    assert.ok(!factory.canStart(p, 'heragon:quest_b'));
+  });
+
+  it('quest già completata (non repeatable) — start negato', () => {
+    const p = makePlayer(5, { completed: [['heragon:quest_no_req', {}]] });
+    assert.ok(!factory.canStart(p, 'heragon:quest_no_req'));
+  });
+
+  it('quest già attiva — start negato', () => {
+    const p = makePlayer(5, { active: ['heragon:quest_no_req'] });
+    assert.ok(!factory.canStart(p, 'heragon:quest_no_req'));
+  });
+
+  it('quest repeatable già completata — start consentito', () => {
+    const p = makePlayer(5, { completed: [['heragon:repeatable', {}]] });
+    assert.ok(factory.canStart(p, 'heragon:repeatable'));
+  });
+});
+
+// ---- level: prefix ----
+
+describe('canStart — level: prefix', () => {
+  it('requires level:3, pg Lv 6 — start consentito', () => {
+    const p = makePlayer(6, { completed: [['heragon:quest_a', {}]] });
+    assert.ok(factory.canStart(p, 'heragon:quest_level_3'));
+  });
+
+  it('requires level:3, pg Lv 3 — start consentito (uguale)', () => {
+    const p = makePlayer(3, { completed: [['heragon:quest_a', {}]] });
+    assert.ok(factory.canStart(p, 'heragon:quest_level_3'));
+  });
+
+  it('requires level:3, pg Lv 2 — start negato', () => {
+    const p = makePlayer(2, { completed: [['heragon:quest_a', {}]] });
+    assert.ok(!factory.canStart(p, 'heragon:quest_level_3'));
+  });
+
+  it('requires solo level:5, pg Lv 5 — start consentito', () => {
+    const p = makePlayer(5);
+    assert.ok(factory.canStart(p, 'heragon:quest_level_5'));
+  });
+
+  it('requires solo level:5, pg Lv 4 — start negato', () => {
+    const p = makePlayer(4);
+    assert.ok(!factory.canStart(p, 'heragon:quest_level_5'));
+  });
+
+  it('requires quest + level:3, pg Lv 6 ma quest non completata — start negato', () => {
+    const p = makePlayer(6);
+    assert.ok(!factory.canStart(p, 'heragon:quest_level_3'));
+  });
+});


### PR DESCRIPTION
## Summary

This PR contains ~25 commits from the [AnathemaMUD](https://github.com/AnathemaMud) fork, adding quality-of-life features, bug fixes, and new APIs to the core Ranvier-TS engine. All changes are backward-compatible.

---

## Features

### Command system improvements
- **`category` + `displayAs` optional fields on `Command`** — Commands can now specify a logical `category` (e.g. `'admin'`, `'combat'`, `'social'`) and a `displayAs` name for clean command listing, independent from the file/keyword name.
- **`CommandManager.find()` prefers lower `requiredRole` over insertion order** — When multiple commands share the same keyword, the one with the lowest `requiredRole` wins. This allows overrides: a bundle can ship a default command, and an admin bundle can shadow it with a stricter `requiredRole` version.

### Broadcast & prompt enhancements
- **`Broadcast.progress()` tip character** — New `tipChar` parameter (default `'>'`) for cleaner progress bar rendering (e.g. `[======>   ]`).
- **`Broadcast.prompt` skips bare prompt when extraPrompts exist** — Avoids duplicate empty prompt line when a module has already queued a custom `extraPrompt`.
- **Short prompt token aliases** — Added common single-char aliases: `%h`/`%H` for health (current/max), `%m`/`%M` for mana, `%v`/`%V` for movement, `%x`/`%t` for exp/tnl, `%l`/`%g` for level/gold, `%n` for target name. All map to existing `%attribute.*` tokens internally.
- **Prompt regex simplified** — Single `%` prefix only (legacy `%` prefix removed), plus `player.emit('logout')` fires before `removeAllListeners` on disconnect.

### NPC & Room
- **`roomDesc` field on `Npc`** — Native field for room listing descriptions, with fallback to `name` (matching the existing pattern in `Item`/`Room`). Enables cleaner MUD room displays (e.g. show "A tall guard stands here" instead of repeating the NPC keyword).
- **`noInferExits` flag on `Room`** — Rooms can opt out of auto-generated exits from adjacent coordinates, useful when movement is handled by a custom overland system or when coordinate-based exit inference would create false connections.
- **`findExit()` prioritizes exact match before prefix match** — `room.findExit('nord')` matches exactly before falling back to `'n'` prefix. Fixes false positives when direction names overlap.
- **`sector` field in `IRoomDef`** — Room definitions can declare a `sector` type (e.g. `'city'`, `'forest'`, `'desert'`) for movement cost or ambient descriptions.

### Quest system
- **Quest `requires` supports `level:N` prefix** — Quest prerequisites can include `level:5` to gate access by player level, in addition to quest-ID requirements.
- **`QuestFactory` returns `null` instead of throwing on invalid ID** — Non-existent quest IDs return `null` gracefully; `QuestTracker` skips `null` quests on hydrate. Prevents cascade crashes when quest data references quests that were removed during development.
- **`Quest.hydrate()` skips missing goals** — If a quest goal type is no longer registered, it logs a warning instead of crashing.

### Configuration & effects
- **`Config.set()`** — New method for runtime configuration changes, complementing the existing `Config.get()`.
- **`EffectFactory` converts `duration: -1` to `Infinity` at runtime** — Allows writing `-1` in YAML for permanent effects (more intuitive than `Infinity`).
- **`effect.activate()` called in `EffectList.add()`** — Fires `effectActivated` event when an effect is added to a character, enabling passive effect triggers.

### Party system
- **Party `unfollow` on disband/delete** — Party members automatically unfollow when the party is disbanded or deleted.
- **Party `name` property** — Parties can have a human-readable name.

### Skill & hot-reload
- **`Skill` tracks source path** — Stores the originating bundle path for hot-reload awareness.
- **`Skill.getDamage()` forwarded from config** — Skill instances expose a `getDamage()` method that delegates to the YAML `config.damage` function, enabling cleaner skill definitions.

### Other
- **`PlayerRoles.OWNER`** — New role constant (`role >= 3`) between ADMIN and the numeric ceiling, for owner-level commands.
- **`Channel.send()` removes duplicate sends** — Fixes messages being broadcast twice when a channel targets both a room audience and a global audience.
- **HelpManager: prefer name-prefix match over keyword/alias match** — Makes `help <command>` more predictable when command names overlap with keywords.
- **`_prompted = true` restored after prompt rendering** — Fixes a regression where the flag was cleared prematurely.
- **Container items loaded from YAML on fresh spawn** — Container contents (e.g. a bag with starting items) now spawn correctly on character creation instead of relying on inventory checks.
- **Build: include `dist/**` contents in npm pack** — Ensures all compiled output is included when publishing the package.
- **Build: build both ESM and CJS in `prepare` script** — Dual-format output for broader compatibility.

---

## Files changed

25 files, +356 insertions, -68 deletions

| File | Changes |
|------|---------|
| `src/Command.ts` | +6: `category`, `displayAs` fields |
| `src/CommandManager.ts` | +10/-3: lower `requiredRole` priority |
| `src/Broadcast.ts` | +28/-31: `tipChar` param, prompt skip, prompt fix |
| `src/Player.ts` | +40/-24: prompt tokens, logout emit |
| `src/Config.ts` | +7: `Config.set()` |
| `src/Room.ts` | +9/-3: `noInferExits`, exact exit match |
| `src/Npc.ts` | +3: `roomDesc` field |
| `src/Quest*.ts` | +24/-2: `level:N`, null-safe hydrate |
| `src/QuestFactory.ts` | +18/-6: null return on invalid ID |
| `src/EffectFactory.ts` | +4: `-1` → `Infinity` |
| `src/EffectList.ts` | +1: `effect.activate()` call |
| `src/Skill.ts` | +10: source path, `getDamage()` forward |
| `src/Party.ts` | +6/-2: unfollow, name |
| `src/Channel.ts` | +9/-8: deduplicate sends |
| `src/HelpManager.ts` | +7: name-prefix priority |
| `src/PlayerRoles.ts` | +1: `OWNER` constant |
| `src/BundleManager.ts` | +3/-1: tracking |
| `src/Item.ts` | +12/-6: container spawn fix |
| other | build config, tests, types |

---

## Testing

All existing unit tests pass. New unit tests added for `Broadcast.progress()` (`test/unit/Broadcast.js`) and QuestFactory behavior (`tests/quest-factory.test.js`). No breaking changes to existing APIs.